### PR TITLE
Mute GMA ads by default via isApplicationMuted (backend-driven)

### DIFF
--- a/AudienzziOSSDK.podspec
+++ b/AudienzziOSSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'AudienzziOSSDK'
-    spec.version  = '0.2.4'
+    spec.version  = '0.2.5'
     spec.license  = { :type => 'Apache-2.0', :file => 'LICENSE' }
     spec.homepage = 'https://github.com/audienzz/audienzz-ios-sdk'
     spec.authors  = { 'Audienzz <tech@audienzz.ch>' => 'https://audienzz.ch' }

--- a/Sources/AudienzziOSSDK/Audienzz.swift
+++ b/Sources/AudienzziOSSDK/Audienzz.swift
@@ -285,7 +285,8 @@ public class Audienzz: NSObject {
             AULogEvent.logDebug("setAppVolume: \(volume) is out of [0.0, 1.0], clamped to \(clamped)")
         }
         MobileAds.shared.applicationVolume = clamped
-        AULogEvent.logDebug("GMA app volume updated to \(clamped)")
+        MobileAds.shared.isApplicationMuted = (clamped == 0)
+        AULogEvent.logDebug("GMA app volume updated to \(clamped), muted=\(clamped == 0)")
     }
 
     public var timeoutMillis: Int {
@@ -365,7 +366,8 @@ public class Audienzz: NSObject {
     private func applyGamAppVolume(_ volume: Float) {
         let clamped = min(max(volume, 0), 1)
         MobileAds.shared.applicationVolume = clamped
-        AULogEvent.logDebug("GMA app volume set to \(clamped)")
+        MobileAds.shared.isApplicationMuted = (clamped == 0)
+        AULogEvent.logDebug("GMA app volume set to \(clamped), muted=\(clamped == 0)")
     }
 
     private func handleInitializationResultStatus(


### PR DESCRIPTION
Set the GMA mute flag alongside app volume so ads are muted when the backend-driven volume resolves to 0, and audible when it is non-zero. Previously only applicationVolume/appVolume was set (never the mute flag), so GMA full-screen video ads could still play audio.