### PR TITLE
Fix/ios audit 2026 08

### DIFF
--- a/AudienzziOSSDK.podspec
+++ b/AudienzziOSSDK.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
                       :tag => '0.2.6' }
 
     spec.swift_version         = '5.0'
-    spec.ios.deployment_target = '13.0'
+    spec.ios.deployment_target = '15.0'
 
     spec.static_framework      = true
     spec.requires_arc          = true
@@ -17,8 +17,8 @@ Pod::Spec.new do |spec|
     spec.source_files          = 'Sources/**/*.swift'
     spec.exclude_files         = 'Tests', 'Examples'
 
-    spec.dependency 'PrebidMobile', '~> 3.0'
-    spec.dependency 'PrebidMobileGAMEventHandlers', '~> 3.0'
+    spec.dependency 'PrebidMobile', '~> 3.3'
+    spec.dependency 'PrebidMobileGAMEventHandlers', '~> 3.3'
     spec.dependency 'SQLite.swift', '~> 0.14'
     spec.dependency 'Google-Mobile-Ads-SDK', '~> 13.0'
     spec.dependency 'GoogleAds-IMA-iOS-SDK', '~> 3.26'

--- a/Package.swift
+++ b/Package.swift
@@ -26,11 +26,11 @@ let package = Package(
                 .product(name: "SQLite", package: "SQLite.swift"),
                 .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads"),
                 .product(name: "GoogleInteractiveMediaAds", package: "swift-package-manager-google-interactive-media-ads-ios")
-            ],
+            ]
         ),
         .testTarget(
             name: "AudienzziOSSDKTests",
-            dependencies: ["AudienzziOSSDK"],
+            dependencies: ["AudienzziOSSDK"]
         )
     ]
 )

--- a/Sources/AudienzziOSSDK/AdUnitConfiguration/AUTargeting/AUTargeting.swift
+++ b/Sources/AudienzziOSSDK/AdUnitConfiguration/AUTargeting/AUTargeting.swift
@@ -244,10 +244,18 @@ public class AUTargeting: NSObject {
     // MARK: - Global User Data (user.ext.data)
 
     public func addUserData(key: String, value: String) {
+        // userExt is nil until first set; optional-chaining alone silently
+        // dropped the write. Initialize it so the value actually lands.
+        if Targeting.shared.userExt == nil {
+            Targeting.shared.userExt = [:]
+        }
         Targeting.shared.userExt?["\(key)"] = value
     }
 
     public func updateUserData(key: String, value: Set<String>) {
+        if Targeting.shared.userExt == nil {
+            Targeting.shared.userExt = [:]
+        }
         Targeting.shared.userExt?["\(key)"] = value
     }
 
@@ -324,31 +332,31 @@ public class AUTargeting: NSObject {
     }
 
     public func setGlobalOrtbConfig(ortbConfig: String) {
-        let customOrtb = ArbitraryGlobalORTBHelper.init(ortb: ortbConfig)
-            .getValidatedORTBDict()
-
-        let schainOrtb: [String: Any]?
-
-        if let schainConfig = Audienzz.shared.audienzzSchainObjectConfig {
-            schainOrtb = ArbitraryGlobalORTBHelper.init(ortb: schainConfig)
-                .getValidatedORTBDict()
-        } else {
-            schainOrtb = nil
-        }
-
-        guard let customOrtb = customOrtb else {
+        guard let customOrtb = ArbitraryGlobalORTBHelper.init(ortb: ortbConfig)
+            .getValidatedORTBDict() else {
             AULogEvent.logDebug(
                 "Provided ortb config couldn't be parsed successfully"
             )
             return
         }
 
-        var combinedOrtb: [String: Any]
-        if let schainOrtb = schainOrtb {
-            combinedOrtb = schainOrtb.deepMerging(with: customOrtb)
-        } else {
-            combinedOrtb = customOrtb
+        // Start from the current global ORTB config so previously-set publisher
+        // data (contextual app.content.data, user.ext.data, etc.) is preserved
+        // and merged into — not replaced — by this fragment.
+        var combinedOrtb: [String: Any] = [:]
+        if let existing = Targeting.shared.getGlobalORTBConfig(),
+           let existingOrtb = ArbitraryGlobalORTBHelper.init(ortb: existing)
+            .getValidatedORTBDict() {
+            combinedOrtb = existingOrtb
         }
+
+        if let schainConfig = Audienzz.shared.audienzzSchainObjectConfig,
+           let schainOrtb = ArbitraryGlobalORTBHelper.init(ortb: schainConfig)
+            .getValidatedORTBDict() {
+            combinedOrtb = combinedOrtb.deepMerging(with: schainOrtb)
+        }
+
+        combinedOrtb = combinedOrtb.deepMerging(with: customOrtb)
 
         // Always embed Audienzz SDK metadata in app.ext.audienzz so every
         // Prebid request carries the SDK identifier and version.

--- a/Sources/AudienzziOSSDK/AdUnitConfiguration/AUTargeting/CustomTargetingManager.swift
+++ b/Sources/AudienzziOSSDK/AdUnitConfiguration/AUTargeting/CustomTargetingManager.swift
@@ -80,9 +80,12 @@ class CustomTargetingManager {
 
     /** For GAM requests - apply global targeting  */
     func applyToGamRequest(request: AdManagerRequest) -> AdManagerRequest {
-        // Start with publisher keys, then overlay SDK-reserved keys so they
-        // always win — publisher can never overwrite them.
-        var targeting = targetingMap
+        // Merge into whatever the publisher already set on the request (e.g.
+        // direct-sold GAM line-item keys) — assigning outright wiped those and
+        // broke direct-sold delivery. Then overlay SDK keys, then reserved keys
+        // last so the SDK's own values always win.
+        var targeting = request.customTargeting ?? [:]
+        targetingMap.forEach { targeting[$0.key] = $0.value }
         targeting["au_sdk"] = sdkPlatform
         if !sdkVersion.isEmpty {
             targeting["au_v"] = sdkVersion

--- a/Sources/AudienzziOSSDK/AdUnitConfiguration/Remote/RemoteConfigFetcher.swift
+++ b/Sources/AudienzziOSSDK/AdUnitConfiguration/Remote/RemoteConfigFetcher.swift
@@ -27,11 +27,24 @@ final class RemoteConfigFetcher {
     }
 
     func fetchAdUnitConfigs(remoteUrl: URL, publisherId: String) async throws -> [RemoteAdConfiguration] {
-        try await fetch(
+        let data = try await fetchData(
             remoteUrl: remoteUrl,
-            pathComponents: ["publishers", publisherId, "ad-configs"],
-            as: [RemoteAdConfiguration].self
+            pathComponents: ["publishers", publisherId, "ad-configs"]
         )
+
+        do {
+            // Lossy decode: a single malformed ad-config entry must not discard
+            // every other (valid) ad unit's config. Skip the bad ones instead.
+            let items = try JSONDecoder().decode([FailableDecodable<RemoteAdConfiguration>].self, from: data)
+            let configs = items.compactMap { $0.value }
+            let skipped = items.count - configs.count
+            if skipped > 0 {
+                AULogEvent.logDebug("Remote Config: skipped \(skipped) malformed ad-config ent\(skipped == 1 ? "ry" : "ries")")
+            }
+            return configs
+        } catch {
+            throw RemoteConfigError.decodingFailed(error)
+        }
     }
 
     func fetchAdUnitConfig(remoteUrl: URL, publisherId: String, adConfigId: String) async throws -> RemoteAdConfiguration {
@@ -51,6 +64,19 @@ private extension RemoteConfigFetcher {
         pathComponents: [String],
         as type: T.Type
     ) async throws -> T {
+        let data = try await fetchData(remoteUrl: remoteUrl, pathComponents: pathComponents)
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw RemoteConfigError.decodingFailed(error)
+        }
+    }
+
+    func fetchData(
+        remoteUrl: URL,
+        pathComponents: [String]
+    ) async throws -> Data {
         let requestURL = pathComponents.reduce(remoteUrl) { url, component in
             url.appendingPathComponent(component)
         }
@@ -61,10 +87,17 @@ private extension RemoteConfigFetcher {
             throw RemoteConfigError.invalidResponse
         }
 
-        do {
-            return try JSONDecoder().decode(T.self, from: data)
-        } catch {
-            throw RemoteConfigError.decodingFailed(error)
-        }
+        return data
+    }
+}
+
+/// Decodes to `nil` instead of throwing when the underlying element is
+/// malformed, so a lossy array decode can skip bad entries.
+private struct FailableDecodable<Base: Decodable>: Decodable {
+    let value: Base?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try? container.decode(Base.self)
     }
 }

--- a/Sources/AudienzziOSSDK/AdUnitViews/AUAdView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/AUAdView.swift
@@ -111,12 +111,20 @@ public class AUAdView: VisibleView {
         self.frame = CGRect(x: origin.x, y: origin.y, width: 0, height: 0)
     }
     
-    internal func defaultVideoParameters() -> VideoParameters {
+    /// Builds the fallback video parameters used when the publisher doesn't
+    /// supply their own. `placement`/`plcmnt` must reflect the ad format so
+    /// DSPs classify (and price) the inventory correctly — a fixed `.InBanner`
+    /// default misclassified all interstitial/rewarded video.
+    internal func defaultVideoParameters(
+        placement: Signals.Placement = .InBanner,
+        plcmnt: Signals.Plcmnt? = nil
+    ) -> VideoParameters {
         let videoParameters = VideoParameters(mimes: ["video/mp4"])
         videoParameters.api = [Signals.Api.MRAID_1, Signals.Api.MRAID_2, Signals.Api.MRAID_3, Signals.Api.OMID_1]
         videoParameters.protocols = [Signals.Protocols.VAST_2_0]
         videoParameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
-        videoParameters.placement = Signals.Placement.InBanner
+        videoParameters.placement = placement
+        videoParameters.plcmnt = plcmnt
         return videoParameters
     }
 }

--- a/Sources/AudienzziOSSDK/AdUnitViews/AUAdView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/AUAdView.swift
@@ -74,6 +74,16 @@ public class AUAdView: VisibleView {
     internal dynamic func fetchRequest(_ gamRequest: GAMRequest) {}
     internal var isInitialAutorefresh: Bool = true
 
+    /// M8: re-run the lazy-load trigger after `createAd` has wired up the request.
+    /// Visibility is edge-triggered, so if the view became visible *before*
+    /// createAd ran (e.g. async remote-config setup), `detectVisible` already
+    /// fired and bailed on the nil request — leaving the slot permanently dead.
+    /// Calling it again here loads it if it's currently on screen.
+    internal func loadIfAlreadyVisible() {
+        guard isLazyLoad, !isLazyLoaded, isViewCurrentlyVisible else { return }
+        detectVisible()
+    }
+
     // prefetchMarginPoints is declared and implemented in VisibleView.
     // See VisibleView.prefetchMarginPoints for the full KDoc.
     // Defaults to 200 pt. Set to 0 for exact-visibility loading.

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/BannerView/AUBannerView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/BannerView/AUBannerView.swift
@@ -152,6 +152,8 @@ public class AUBannerView: AUAdView {
 
         if !self.isLazyLoad {
             fetchRequest(gamRequest)
+        } else {
+            loadIfAlreadyVisible()
         }
     }
 }

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/BannerView/AUBannerView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/BannerView/AUBannerView.swift
@@ -72,6 +72,17 @@ public class AUBannerView: AUAdView {
         self.gamRequest = nil
         self.eventHandler = nil
     }
+
+    /// Explicitly tears down the ad: stops auto-refresh and releases the Prebid
+    /// ad unit, GAM request, and event handler. Prefer this over relying on
+    /// `removeFromSuperview` as a destructor — call it when you're done with the
+    /// ad (e.g. the owning controller's `deinit`). Safe to call more than once.
+    public func destroy() {
+        adUnit?.stopAutoRefresh()
+        self.adUnit = nil
+        self.gamRequest = nil
+        self.eventHandler = nil
+    }
     
     public func addAdditionalSize(sizes: [CGSize]) {
         adUnit.addAdditionalSize(sizes: sizes)

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/InstreamView/AUInstreamView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/InstreamView/AUInstreamView.swift
@@ -67,7 +67,7 @@ public class AUInstreamView: AUAdView {
      Function for prepare and make request for ad. If Lazy load enabled request will be send only when view will appear on screen.
      */
     public func createAd(size: CGSize) {
-        adUnit.videoParameters = videoParameters?.unwrap() ?? defaultVideoParameters()
+        adUnit.videoParameters = videoParameters?.unwrap() ?? defaultVideoParameters(placement: .InStream, plcmnt: .Instream)
         
         if !self.isLazyLoad {
             fetchRequest()

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
@@ -121,9 +121,18 @@ public class AUInterstitialView: AUAdView {
         
         if !self.isLazyLoad {
             fetchRequest(gamRequest)
+        } else {
+            #if DEBUG
+            // M7: a fullscreen interstitial placeholder has a zero frame, so the
+            // visibility-based lazy trigger can only fire if the view is actually
+            // added to the hierarchy and scrolled on screen. If it isn't, set
+            // isLazyLoad = false so createAd fetches immediately.
+            AULogEvent.logDebug("[AUInterstitialView] lazy load enabled — the ad fetches only once this view reaches the viewport. For a standalone interstitial, use isLazyLoad = false.")
+            #endif
+            loadIfAlreadyVisible()
         }
     }
-    
+
     public func connectHandler(_ eventHandler: AUInterstitialEventHandler) {
         self.eventHandler = AUInterstitialHandler(handler: eventHandler, adView: self)
         makeCreationEvent()

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
@@ -77,7 +77,17 @@ public class AUInterstitialView: AUAdView {
         adUnit = nil
         self.eventHandler = nil
     }
-    
+
+    /// Explicitly tears down the ad: stops auto-refresh and releases the Prebid
+    /// ad unit and event handler. Prefer this over relying on
+    /// `removeFromSuperview` as a destructor. Safe to call more than once.
+    public func destroy() {
+        adUnit?.stopAutoRefresh()
+        adUnit = nil
+        self.gamRequest = nil
+        self.eventHandler = nil
+    }
+
     deinit {
         self.eventHandler = nil
     }

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/Interstitial/AUInterstitialView.swift
@@ -96,7 +96,7 @@ public class AUInterstitialView: AUAdView {
     public func createAd(with gamRequest: AdManagerRequest, adUnitID: String) {
         adUnit.bannerParameters = bannerParameters.makeBannerParameters()
         
-        adUnit.videoParameters = self.videoParameters?.unwrap() ?? defaultVideoParameters()
+        adUnit.videoParameters = self.videoParameters?.unwrap() ?? defaultVideoParameters(placement: .Interstitial, plcmnt: .Interstitial)
         
         AUEventsManager.shared.checkImpression(self, adUnitID: adUnitID)
         self.gadUnitID = adUnitID

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/RemoteConfigBannerView/AURemoteConfigBannerView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/RemoteConfigBannerView/AURemoteConfigBannerView.swift
@@ -98,9 +98,16 @@ public class AURemoteConfigBannerView: VisibleView {
             isLazyLoad: true
         )
 
-        bannerView.adUnit.setAutoRefreshMillis(
-            time: Double((remoteConfig.config.refreshTimeSeconds ?? Self.defaultRefreshSeconds) * 1000)
-        )
+        // M4: route refresh through adUnitConfiguration (not adUnit directly) so
+        // autorefreshEventModel is updated — otherwise the stale-aware smart
+        // refresh logic reads autorefreshTime == 0 and never engages, and
+        // analytics report isAutorefresh = false.
+        // M22: Prebid enforces a 30s floor (values below are silently rejected).
+        // Clamp positive values here so Prebid and the SDK's stale-aware refresh
+        // use the same effective cadence.
+        let configuredRefreshMs = Double((remoteConfig.config.refreshTimeSeconds ?? Self.defaultRefreshSeconds) * 1000)
+        let refreshMs = configuredRefreshMs > 0 ? max(configuredRefreshMs, 30_000) : configuredRefreshMs
+        bannerView.adUnitConfiguration.setAutoRefreshMillis(time: refreshMs)
         bannerView.smartRefresh = true
         bannerView.prefetchMarginPoints = CGFloat(remoteConfig.config.prefetchDistancePt ?? Self.defaultPrefetchDistancePt)
 

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/RemoteConfigInterstitial/AURemoteConfigInterstitial.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/RemoteConfigInterstitial/AURemoteConfigInterstitial.swift
@@ -11,6 +11,7 @@ import GoogleMobileAds
 
 public enum AURemoteConfigInterstitialError: Error {
     case noRemoteConfig
+    case deallocated
 }
 /**
  AURemoteConfigInterstitial.
@@ -54,20 +55,26 @@ public class AURemoteConfigInterstitial: NSObject {
         }
 
         interstitialAdUnit?.fetchDemand(adObject: gamRequest) { [weak self] result in
-            guard let self = self else { return }
+            guard self != nil else {
+                completion(.failure(AURemoteConfigInterstitialError.deallocated))
+                return
+            }
 
             AdManagerInterstitialAd.load(
                 with: remoteConfig.gamConfig.adUnitPath,
                 request: gamRequest
             ) { [weak self] ad, error in
-                guard let self = self else { return }
-                
+                guard let self = self else {
+                    completion(.failure(AURemoteConfigInterstitialError.deallocated))
+                    return
+                }
+
                 if let error = error {
                     AULogEvent.logDebug("[AURemoteConfigInterstitial] Failed to load interstitial: \(error)")
                     completion(.failure(error))
                     return
                 }
-                
+
                 self.gamInterstitialAd = ad
                 completion(.success(()))
             }
@@ -95,5 +102,9 @@ public class AURemoteConfigInterstitial: NSObject {
 
         ad.fullScreenContentDelegate = delegate
         ad.present(from: rootViewController)
+        // GAM interstitials are single-use: once presented the ad can't be shown
+        // again. Clear it so isReady reflects reality and a second show() doesn't
+        // silently no-op on a spent ad (publisher must reload for the next show).
+        gamInterstitialAd = nil
     }
 }

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
@@ -99,6 +99,13 @@ public class AURewardedView: AUAdView {
         self.gamRequest = AUTargeting.shared.customTargetingManager.applyToGamRequest(request: gamRequest)
         if !self.isLazyLoad {
             fetchRequest(gamRequest)
+        } else {
+            #if DEBUG
+            // M7: see AUInterstitialView — a fullscreen rewarded placeholder has a
+            // zero frame, so lazy load only fires if the view reaches the viewport.
+            AULogEvent.logDebug("[AURewardedView] lazy load enabled — the ad fetches only once this view reaches the viewport. For a standalone rewarded ad, use isLazyLoad = false.")
+            #endif
+            loadIfAlreadyVisible()
         }
     }
     

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
@@ -60,7 +60,17 @@ public class AURewardedView: AUAdView {
         adUnit = nil
         self.eventHandler = nil
     }
-    
+
+    /// Explicitly tears down the ad: stops auto-refresh and releases the Prebid
+    /// ad unit and event handler. Prefer this over relying on
+    /// `removeFromSuperview` as a destructor. Safe to call more than once.
+    public func destroy() {
+        adUnit?.stopAutoRefresh()
+        adUnit = nil
+        self.gamRequest = nil
+        self.eventHandler = nil
+    }
+
     deinit {
         self.eventHandler = nil
     }

--- a/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Original/RewardedView/AURewardedView.swift
@@ -79,7 +79,7 @@ public class AURewardedView: AUAdView {
     public func createAd(with gamRequest: AdManagerRequest, adUnitID: String) {
         AUEventsManager.shared.checkImpression(self, adUnitID: adUnitID)
         self.gadUnitID = adUnitID
-        adUnit.videoParameters = videoParameters?.unwrap() ?? defaultVideoParameters()
+        adUnit.videoParameters = videoParameters?.unwrap() ?? defaultVideoParameters(placement: .Interstitial, plcmnt: .Interstitial)
         let ppid = PPIDManager.shared.getPPID()
         
         if let ppid = ppid {

--- a/Sources/AudienzziOSSDK/AdUnitViews/Rendering/Interstitial/AUInterstitialRenderingView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Rendering/Interstitial/AUInterstitialRenderingView.swift
@@ -82,9 +82,16 @@ public class AUInterstitialRenderingView: AUAdView {
         self.adUnit = InterstitialRenderingAdUnit(configID: configId,
                                                   minSizePercentage: minSizePerc ?? .zero,
                                                   eventHandler: interstitialEventHandler)
-        
+        // M11: without this the inherited adUnitConfiguration (an IUO) stays nil
+        // and any access to the documented config surface crashes. Mirrors the
+        // rewarded rendering view.
+        self.adUnitConfiguration = AUInterstitialRenderingConfiguration(adUnit: adUnit)
+
         makeCreationEvent(adFormat, eventHandler: eventHandler)
     }
+
+    /// Whether the interstitial has finished loading and can be shown.
+    @objc public var isReady: Bool { adUnit?.isReady ?? false }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -114,6 +121,11 @@ public class AUInterstitialRenderingView: AUAdView {
     
     /// It is expected from the user to call this method on main thread
     public func showAd(_ controller: UIViewController) {
+        // M12: showing before the ad is ready silently drops a won impression.
+        guard adUnit.isReady else {
+            AULogEvent.logDebug("[AUInterstitialRenderingView] showAd called but ad is not ready; ignoring")
+            return
+        }
         adUnit.show(from: controller)
     }
     

--- a/Sources/AudienzziOSSDK/AdUnitViews/Rendering/Rewarded/AURewardedRenderingView.swift
+++ b/Sources/AudienzziOSSDK/AdUnitViews/Rendering/Rewarded/AURewardedRenderingView.swift
@@ -80,8 +80,16 @@ public class AURewardedRenderingView: AUAdView {
         }
     }
     
+    /// Whether the rewarded ad has finished loading and can be shown.
+    @objc public var isReady: Bool { rewardedAdUnit?.isReady ?? false }
+
     /// It is expected from the user to call this method on main thread
     public func showAd(_ controller: UIViewController) {
+        // M12: showing before the ad is ready silently drops a won impression.
+        guard rewardedAdUnit.isReady else {
+            AULogEvent.logDebug("[AURewardedRenderingView] showAd called but ad is not ready; ignoring")
+            return
+        }
         rewardedAdUnit.show(from: controller)
     }
     

--- a/Sources/AudienzziOSSDK/Audienzz.swift
+++ b/Sources/AudienzziOSSDK/Audienzz.swift
@@ -117,11 +117,32 @@ public class Audienzz: NSObject {
         // The value will be overridden below once the remote config is fetched.
         applyGamAppVolume(0)
 
-        try await AudienzzRemoteConfig.shared.fetchPublisherConfig()
+        do {
+            try await AudienzzRemoteConfig.shared.fetchPublisherConfig()
+        } catch {
+            // Don't abort init on fetch failure — fall through to the fallback
+            // below so a first-launch user on a flaky network can still monetize.
+            AULogEvent.logDebug(
+                "Audienzz Remote Config fetch failed: \(error). Falling back to default Prebid host/account."
+            )
+        }
 
         guard let publisherConfig = AudienzzRemoteConfig.shared.publisherConfig else {
+            // Cold start with no cache and no network: initialize Prebid with the
+            // hardcoded default host/account instead of leaving the SDK dead.
             AULogEvent.logDebug(
-                "Initialization Failed because PrebidUrl is empty"
+                "Audienzz Remote Config unavailable — initializing with default Prebid host/account"
+            )
+            setupRemotePrebid(
+                AudienzzRemoteConfig.shared.publisherId ?? "1",
+                prebidServerAccountId: prebidServerAccountId,
+                prebidStatusUrl: customStatusEndpoint,
+                appVolume: 0
+            )
+            initializePrebid(
+                serverURL: customPrebidServerURL,
+                gadMobileAdsVersion: gadMobileAdsVersion,
+                enablePPID: enablePPID
             )
             return
         }
@@ -169,9 +190,23 @@ public class Audienzz: NSObject {
             AUTargeting.shared.itunesID = iosOrtb.bundleId
         }
 
+        initializePrebid(
+            serverURL: publisherConfig.prebidServer.url,
+            gadMobileAdsVersion: gadMobileAdsVersion,
+            enablePPID: enablePPID
+        )
+    }
+
+    /// Shared Prebid initialization used by the remote-config flow (both the
+    /// happy path and the default-host fallback).
+    private func initializePrebid(
+        serverURL: String,
+        gadMobileAdsVersion: String?,
+        enablePPID: Bool
+    ) {
         do {
             try Prebid.initializeSDK(
-                serverURL: publisherConfig.prebidServer.url,
+                serverURL: serverURL,
                 gadMobileAdsVersion: gadMobileAdsVersion
             ) { status, error in
                 if let error = error {

--- a/Sources/AudienzziOSSDK/Audienzz.swift
+++ b/Sources/AudienzziOSSDK/Audienzz.swift
@@ -127,31 +127,35 @@ public class Audienzz: NSObject {
         }
 
         setupRemotePrebid(
-            publisherConfig.ortb?.schain?.sellerId ?? "1",
+            AudienzzRemoteConfig.shared.publisherId ?? "1",
             prebidServerAccountId: publisherConfig.prebidServer.accountId,
             prebidStatusUrl: publisherConfig.prebidServer.statusUrl,
             appVolume: publisherConfig.gamConfig?.appVolume ?? 0
         )
 
         if let schain = publisherConfig.ortb?.schain {
-            let schainJson = """
-            {
-                "source": {
-                    "ext": {
-                        "schain": {
+            // Build via JSONSerialization instead of string interpolation so a
+            // quote/backslash in the backend-provided asi/sid can't produce
+            // malformed JSON (which silently drops the schain).
+            let schainDict: [String: Any] = [
+                "source": [
+                    "ext": [
+                        "schain": [
                             "complete": 1,
-                            "nodes": [{
-                                "asi": "\(schain.advertisingSystemDomain)",
-                                "sid": "\(schain.sellerId)",
+                            "nodes": [[
+                                "asi": schain.advertisingSystemDomain,
+                                "sid": schain.sellerId,
                                 "hp": 1
-                            }],
+                            ]],
                             "ver": "1.0"
-                        }
-                    }
-                }
+                        ]
+                    ]
+                ]
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: schainDict),
+               let schainJson = String(data: data, encoding: .utf8) {
+                setSchainObject(schain: schainJson)
             }
-            """
-            setSchainObject(schain: schainJson)
         }
 
         if let ortb = publisherConfig.ortb {
@@ -252,6 +256,9 @@ public class Audienzz: NSObject {
                         AULogEvent.logDebug(
                             "Initialization Error: \(error.localizedDescription)"
                         )
+                        // Must still resolve the bridge promise, otherwise the
+                        // RN/JS caller hangs forever on init failure.
+                        completion?()
                         return
                     }
 
@@ -290,15 +297,24 @@ public class Audienzz: NSObject {
     }
 
     public var timeoutMillis: Int {
+        // Assigning Prebid's `timeoutMillis` also updates `timeoutMillisDynamic`
+        // (via its didSet), so the auction picks up the value AND the getter
+        // reflects what was set. Writing only Dynamic left the getter stale.
         get { Prebid.shared.timeoutMillis }
-        set {
-            Prebid.shared.timeoutMillisDynamic = NSNumber(value: newValue)
-        }
+        set { Prebid.shared.timeoutMillis = newValue }
     }
 
-    public var timeoutMillisDynamic: NSNumber?
+    public var timeoutMillisDynamic: NSNumber? {
+        get { Prebid.shared.timeoutMillisDynamic }
+        set { Prebid.shared.timeoutMillisDynamic = newValue }
+    }
 
-    public var storedAuctionResponse: String?
+    public var storedAuctionResponse: String? {
+        // Previously a dead stored property — setting it never reached Prebid,
+        // so the stored-auction-response feature silently did nothing.
+        get { Prebid.shared.storedAuctionResponse }
+        set { Prebid.shared.storedAuctionResponse = newValue }
+    }
 
     // MARK: - Stored Bid Response
 

--- a/Sources/AudienzziOSSDK/AudienzzRemoteConfig.swift
+++ b/Sources/AudienzziOSSDK/AudienzzRemoteConfig.swift
@@ -20,7 +20,7 @@ public class AudienzzRemoteConfig: NSObject {
 
     // MARK: - Properties
 
-    private var publisherId: String?
+    private(set) var publisherId: String?
     private var remoteUrl: URL?
 
     private(set) var publisherConfig: RemotePublisherConfiguration?

--- a/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AUBannerHandler.swift
+++ b/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AUBannerHandler.swift
@@ -34,7 +34,11 @@ class AUBannerHandler: NSObject,
     AULogEventType
 {
 
-    let auBannerView: AUBannerView
+    // weak: AUBannerView strongly holds this handler via `eventHandler`. A strong
+    // back-reference here formed a retain cycle that leaked the view, its GAM view
+    // and WKWebView, and the Prebid ad unit — and the leaked dispatcher kept
+    // auctioning an invisible, detached ad indefinitely.
+    weak var auBannerView: AUBannerView?
     let gamView: AdManagerBannerView!
     weak var bannerDelegate: BannerViewDelegate?
     weak var eventDelegate: AppEventDelegate?
@@ -93,7 +97,7 @@ class AUBannerHandler: NSObject,
 
             if actualSize != .zero {
                 gamBannerView.resize(adSizeFor(cgSize: actualSize))
-                auBannerView.onAdSizeChanged?(actualSize)
+                auBannerView?.onAdSizeChanged?(actualSize)
             }
         }
         pendingGAMSize = nil
@@ -108,7 +112,7 @@ class AUBannerHandler: NSObject,
         LogEvent(error.localizedDescription)
 
         let event = AUFailedLoadEvent(
-            adViewId: auBannerView.configId,
+            adViewId: auBannerView?.configId ?? "",
             adUnitID: adUnitID ?? "",
             errorMessage: error.localizedDescription,
             errorCode: error.errorCode ?? -1
@@ -140,7 +144,7 @@ class AUBannerHandler: NSObject,
         LogEvent("bannerViewDidRecordClick")
 
         let event = AUAdClickEvent(
-            adViewId: auBannerView.configId,
+            adViewId: auBannerView?.configId ?? "",
             adUnitID: adUnitID ?? ""
         )
 

--- a/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AUInterstitialHandler.swift
+++ b/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AUInterstitialHandler.swift
@@ -32,7 +32,9 @@ class AUInterstitialHandler: NSObject,
 {
 
     let handler: AUInterstitialEventHandler
-    let adView: AUInterstitialView
+    // weak: AUInterstitialView strongly holds this handler via `eventHandler`; a
+    // strong back-reference leaked the view and the full GAM ad object per screen.
+    weak var adView: AUInterstitialView?
     weak var fullScreentDelegate: FullScreenContentDelegate?
 
     init(handler: AUInterstitialEventHandler, adView: AUInterstitialView) {
@@ -64,7 +66,7 @@ class AUInterstitialHandler: NSObject,
         LogEvent("adDidRecordClick")
 
         let event = AUAdClickEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID
         )
 
@@ -85,7 +87,7 @@ class AUInterstitialHandler: NSObject,
         LogEvent("didFailToPresentFullScreenContentWithError")
 
         let event = AUFailedLoadEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID,
             errorMessage: error.localizedDescription,
             errorCode: error.errorCode ?? -1
@@ -121,7 +123,7 @@ class AUInterstitialHandler: NSObject,
         LogEvent("adDidDismissFullScreenContent")
 
         let event = AUCloseAdEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID
         )
         guard let payload = event.convertToJSONString() else {

--- a/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AURewardedHandler.swift
+++ b/Sources/AudienzziOSSDK/EventHandler/Events/AUGAMWrappers/AURewardedHandler.swift
@@ -32,7 +32,9 @@ class AURewardedHandler: NSObject,
 {
 
     let handler: AURewardedEventHandler
-    let adView: AURewardedView
+    // weak: AURewardedView strongly holds this handler via `eventHandler`; a
+    // strong back-reference leaked the view and the full GAM ad object per screen.
+    weak var adView: AURewardedView?
     weak var fullScreentDelegate: FullScreenContentDelegate?
 
     init(handler: AURewardedEventHandler, adView: AURewardedView) {
@@ -64,7 +66,7 @@ class AURewardedHandler: NSObject,
         LogEvent("adDidRecordClick")
 
         let event = AUAdClickEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID
         )
 
@@ -85,7 +87,7 @@ class AURewardedHandler: NSObject,
         LogEvent("didFailToPresentFullScreenContentWithError")
 
         let event = AUFailedLoadEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID,
             errorMessage: error.localizedDescription,
             errorCode: error.errorCode ?? -1
@@ -119,7 +121,7 @@ class AURewardedHandler: NSObject,
         LogEvent("adDidDismissFullScreenContent")
 
         let event = AUCloseAdEvent(
-            adViewId: adView.configId,
+            adViewId: adView?.configId ?? "",
             adUnitID: adUnitID
         )
         guard let payload = event.convertToJSONString() else {

--- a/Sources/AudienzziOSSDK/EventHandler/Storage/SqliteWrappers/AUSQLiteConfigurator.swift
+++ b/Sources/AudienzziOSSDK/EventHandler/Storage/SqliteWrappers/AUSQLiteConfigurator.swift
@@ -29,10 +29,10 @@ final class AUSQLiteConfigurator: AULocalStorageConfigurator {
         if FileManager.default.fileExists(atPath: newDBPath.path) {
             return
         } else {
-            AUSQLiteDataBaseCreator().createLocalStorage()
+            try AUSQLiteDataBaseCreator().createLocalStorage()
         }
     }
-    
+
     func configureStorageTest() throws {
         let destination = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let newDBPath = destination.appendingPathComponent(SQLiteConstants.dbPathComponentTest)
@@ -40,7 +40,7 @@ final class AUSQLiteConfigurator: AULocalStorageConfigurator {
         if FileManager.default.fileExists(atPath: newDBPath.path) {
             return
         } else {
-            AUSQLiteDataBaseCreator().createLocalStorageTest()
+            try AUSQLiteDataBaseCreator().createLocalStorageTest()
         }
     }
 }

--- a/Sources/AudienzziOSSDK/EventHandler/Storage/SqliteWrappers/AUSQLiteDataBaseCreator.swift
+++ b/Sources/AudienzziOSSDK/EventHandler/Storage/SqliteWrappers/AUSQLiteDataBaseCreator.swift
@@ -19,30 +19,22 @@ import Foundation
 // create database structure
 // used for debug purposes and for modifing db structure
 protocol AULocalStorageCreator {
-    func createLocalStorage()
+    func createLocalStorage() throws
 }
 
 final class AUSQLiteDataBaseCreator: AULocalStorageCreator {
-    func createLocalStorage() {
-        do {
-            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            let db = try Connection("\(path)/\(SQLiteConstants.dbPathComponent)")
-            
-            try createEventsTable(on: db)
-        } catch let error {
-            fatalError(error.localizedDescription)
-        }
+    func createLocalStorage() throws {
+        let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let db = try Connection("\(path)/\(SQLiteConstants.dbPathComponent)")
+
+        try createEventsTable(on: db)
     }
-    
-    func createLocalStorageTest() {
-        do {
-            let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            let db = try Connection("\(path)/\(SQLiteConstants.dbPathComponentTest)")
-            
-            try createEventsTable(on: db)
-        } catch let error {
-            fatalError(error.localizedDescription)
-        }
+
+    func createLocalStorageTest() throws {
+        let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let db = try Connection("\(path)/\(SQLiteConstants.dbPathComponentTest)")
+
+        try createEventsTable(on: db)
     }
 }
 

--- a/Sources/AudienzziOSSDK/Helpers/AUAdViewUtils.swift
+++ b/Sources/AudienzziOSSDK/Helpers/AUAdViewUtils.swift
@@ -333,6 +333,6 @@ public final class AUIMAUtils: NSObject {
     private override init() {}
 
     @objc public func generateInstreamUriForGAM(adUnitID: String, adSlotSizes: [IMAAdSlotSize], customKeywords: [String:String]?) throws -> String {
-        try IMAUtils.shared.generateInstreamUriForGAM(adUnitID: adUnitID, adSlotSizes: adSlotSizes, customKeywords: customKeywords!)
+        try IMAUtils.shared.generateInstreamUriForGAM(adUnitID: adUnitID, adSlotSizes: adSlotSizes, customKeywords: customKeywords ?? [:])
     }
 }

--- a/Sources/AudienzziOSSDK/Helpers/AUNativeApi/AUNativeAd.swift
+++ b/Sources/AudienzziOSSDK/Helpers/AUNativeApi/AUNativeAd.swift
@@ -92,7 +92,11 @@ public class AUNativeAd: NSObject {
     internal init(_ nativeAd: NativeAd) {
         super.init()
         self.nativeAd = nativeAd
-        self.subdelegate = AUNativeAdDelegateType(parent: self)
+        let subdelegate = AUNativeAdDelegateType(parent: self)
+        self.subdelegate = subdelegate
+        // Without this, Prebid's NativeAd never forwards impression/click/expiry
+        // events, so AUNativeAdEventDelegate callbacks never fire.
+        self.nativeAd.delegate = subdelegate
     }
 
     //MARK: registerView function

--- a/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AUVideoParameters.swift
+++ b/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AUVideoParameters.swift
@@ -66,8 +66,12 @@ public class AUVideoParameters: NSObject {
     /// Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.
     public var startDelay: AUVideoStartDelay?
 
-    /// Placement type for the impression.
+    /// Placement type for the impression (deprecated OpenRTB `video.placement`).
     public var placement: AUPlacement?
+
+    /// OpenRTB 2.6 placement type for the impression (`video.plcmnt`).
+    /// Preferred over `placement` by modern DSPs.
+    public var plcmnt: AUPlcmnt?
 
     /// Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed.
     public var linearity: Int?
@@ -117,5 +121,10 @@ public class AUVideoParameters: NSObject {
     /// Placement type for the impression.
     public func setPlacement(_ value: AUPlacement) {
         self.placement = value
+    }
+
+    /// OpenRTB 2.6 placement type for the impression (`video.plcmnt`).
+    public func setPlcmnt(_ value: AUPlcmnt) {
+        self.plcmnt = value
     }
 }

--- a/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AUVideoParameters_Private.swift
+++ b/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AUVideoParameters_Private.swift
@@ -57,6 +57,7 @@ extension AUVideoParameters {
         parameters.protocols = toProtocols()
         parameters.playbackMethod = toPlaybackMethods()
         parameters.placement = placement?.toPlacement
+        parameters.plcmnt = plcmnt?.toPlcmnt
 
         parameters.api = toApi()
         parameters.startDelay = startDelay?.toStartDelay

--- a/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AdVideoPropertyParameters.swift
+++ b/Sources/AudienzziOSSDK/Helpers/AUVideoAPI/AdVideoPropertyParameters.swift
@@ -131,7 +131,39 @@ public enum AUPlacement: Int {
     case InFeed
     case Interstitial
 
+    // NOTE: this enum is 0-based while Prebid's Signals.Placement is 1-based
+    // (InStream=1 … Interstitial=5). Mapping self.rawValue straight through
+    // shifted every value by one (e.g. .Interstitial emitted InFeed). Map to
+    // the named Prebid constants explicitly instead.
     internal var toPlacement: Signals.Placement {
-        Signals.Placement(integerLiteral: self.rawValue)
+        switch self {
+        case .InStream: return .InStream
+        case .InBanner: return .InBanner
+        case .InArticle: return .InArticle
+        case .InFeed: return .InFeed
+        case .Interstitial: return .Interstitial
+        }
+    }
+}
+
+/// # OpenRTB 2.6 - Updated Video Placement (plcmnt) #
+/// ```
+/// | Value | Description          |
+/// |-------|----------------------|
+/// | 1     | Instream             |
+/// | 2     | Accompanying Content |
+/// | 3     | Interstitial         |
+/// | 4     | No Content/Standalone|
+/// ```
+/// Preferred over the deprecated `placement` field by modern DSPs.
+@objc(AUPlcmnt)
+public enum AUPlcmnt: Int {
+    case instream = 1
+    case accompanyingContent = 2
+    case interstitial = 3
+    case noContent = 4
+
+    internal var toPlcmnt: Signals.Plcmnt {
+        Signals.Plcmnt(integerLiteral: self.rawValue)
     }
 }

--- a/Sources/AudienzziOSSDK/Helpers/Private_AdTypes/AUBannerView_Private.swift
+++ b/Sources/AudienzziOSSDK/Helpers/Private_AdTypes/AUBannerView_Private.swift
@@ -176,6 +176,18 @@ extension AUBannerView {
             guard self.adUnit != nil else { return }
             self.lastRefreshTime = Date()
 
+            // H12: Prebid starts its auto-refresh dispatcher synchronously on the
+            // first fetchDemand. When that first fetch is a prefetch-zone load
+            // (fired up to prefetchMarginPoints before the ad is on screen), the
+            // dispatcher would otherwise keep auto-refreshing at 0% viewability.
+            // Under smart refresh, stop it whenever the ad isn't actually visible;
+            // onBecameVisible resumes it (stale-aware) once the ad is ≥20% on screen.
+            // This runs after onBecameVisible has resolved the already-visible case,
+            // so a banner that's on screen at load keeps refreshing normally.
+            if self.smartRefresh, !self.isViewCurrentlyVisible {
+                self.adUnitConfiguration?.stopAutoRefresh()
+            }
+
             /*
              use for debug more deep events
             

--- a/Sources/AudienzziOSSDK/Helpers/Private_AdTypes/AUInstreamView_Private.swift
+++ b/Sources/AudienzziOSSDK/Helpers/Private_AdTypes/AUInstreamView_Private.swift
@@ -32,14 +32,17 @@ extension AUInstreamView {
 
     func fetchRequest() {
         adUnit.fetchDemand { [weak self] bidInfo in
-            guard let self = self,
-                let resultCode = AUResultCode(
-                    rawValue: bidInfo.resultCode.rawValue
-                )
-            else { return }
+            guard let self = self else { return }
+            let resultCode = AUResultCode(rawValue: bidInfo.resultCode.rawValue)
             if resultCode == .audienzzDemandFetchSuccess {
                 self.customKeywords = bidInfo.targetingKeywords
                 self.onLoadInstreamRequest?(bidInfo.targetingKeywords)
+            } else {
+                // On no-bid/timeout/error still request the IMA/GAM tag so
+                // GAM-direct and house demand can fill. Dropping the callback
+                // here forfeits the entire instream impression opportunity.
+                self.customKeywords = nil
+                self.onLoadInstreamRequest?(nil)
             }
         }
     }

--- a/Sources/AudienzziOSSDK/Helpers/VisibleView.swift
+++ b/Sources/AudienzziOSSDK/Helpers/VisibleView.swift
@@ -53,6 +53,11 @@ public class VisibleView: UIView {
     private var contentOffsetObservations = [NSKeyValueObservation]()
     private var isCurrentlyVisible: Bool = false
 
+    /// Whether the view currently meets the visibility threshold (≥20% on screen).
+    /// Exposed so subclasses can tell a prefetch-zone (not-yet-visible) load apart
+    /// from a genuinely visible one.
+    internal var isViewCurrentlyVisible: Bool { isCurrentlyVisible }
+
     // MARK: - Prefetch margin
 
     /// Distance in points before the view enters the viewport that triggers


### PR DESCRIPTION
## Summary

Acts on the July 2026 iOS SDK technical audit (`audienzz-audit-ios.md`), which was run against tag `0.2.4`. Only mute-ads + docs landed between then and `0.2.6`, so essentially every audit finding was still open on `main`.

This PR fixes **all High and Medium findings on `main`** except the ones that are intentionally out of scope (analytics — dead/being rebuilt on `dev-analytics`; and the PPID consent gate, which is expected behavior). 29 files changed. Every commit builds green against the iOS Simulator via the `DemoSwiftApp` target.

The 10 commits are grouped by theme and are readable independently — reviewing commit-by-commit is recommended.

## What's fixed

### Release gates (Phase A) — `fix: audit Phase A release gates + low-risk correctness bugs`
- **H8** — podspec `deployment_target` 13.0 → 15.0 (GMA 13 / iOS-15-only API); Prebid pod floor `~> 3.0` → `~> 3.3` to match SPM.
- **H7** — removed Swift-6-only trailing commas in `Package.swift` (broke SPM resolution on Xcode ≤ 16.2).
- **C1** — instream now invokes the load callback on no-bid/timeout/error (nil keywords) so GAM-direct/house demand can still fill.
- **M10** — `generateInstreamUriForGAM` no longer force-unwraps `customKeywords`.
- **H4** — attach the native ad event subdelegate to Prebid's `NativeAd.delegate` so impression/click/expiry callbacks fire.
- **H6** — SQLite creator throws instead of `fatalError`; the caller already degrades to nil storage, so disk-full / pre-first-unlock no longer crashes the host app.
- **M15** — RN `configureSDK_RN(gadMobileAdsVersion:)` calls `completion` on the init error path (previously the JS promise hung).
- **L2 / timeoutMillis** — `timeoutMillis` setter now consistent with its getter; `storedAuctionResponse` and `timeoutMillisDynamic` proxy `Prebid.shared` instead of being dead.
- **L5** — schain JSON built via `JSONSerialization` (escaping-safe).
- **Remote-config company id** — the remote flow used the schain `sellerId` as the analytics company id; now uses the real `publisherId`.

### High priority — `fix(H3)`, `fix(H10)`, `fix(H11)`, `fix(H12)`
- **H3** — `defaultVideoParameters()` forced `Signals.Placement.InBanner` for every format, so interstitial/rewarded video was misclassified by DSPs. It now takes a placement + plcmnt (interstitial/rewarded → `.Interstitial`, instream → `.InStream`, banner keeps `.InBanner`). Also fixed an off-by-one in `AUPlacement.toPlacement` (0-based enum mapped straight onto Prebid's 1-based `Signals.Placement`) and added `AUPlcmnt` (OpenRTB 2.6 `video.plcmnt`) + `AUVideoParameters.plcmnt`.
- **H10** — remote-config cold-start resilience: lossy ad-config decode (one malformed entry no longer discards every ad unit's config) + fall back to the hardcoded default Prebid host/account when config can't be fetched and there's no cache (first-launch users on flaky networks still monetize).
- **H11** — `AURemoteConfigInterstitial` clears the ad after `present()` (GAM interstitials are single-use; `isReady` stayed true and a second `show()` silently no-oped on a spent ad) and calls `completion` with a `.deallocated` error instead of dropping it.
- **H12** — Prebid starts its auto-refresh dispatcher synchronously on the first `fetchDemand`, so a lazy banner's prefetch-zone load kept auto-refreshing while the ad was still off-screen (0% viewability). Under smart refresh, stop the dispatcher when the ad isn't visible; `onBecameVisible` resumes it once the ad is ≥20% on screen.

### Retain cycles — `fix(H1,H2)`
- **H1/H2** — the GAM event handlers held a strong back-reference to their `AUAdView` while the view held the handler strongly, forming a retain cycle. The only cycle-breaker was an explicit `removeFromSuperview()`, which UIKit doesn't call on teardown — so views leaked along with their GAM view, WKWebView and Prebid ad unit, and (for banners) the leaked dispatcher kept auctioning an invisible ad indefinitely. Handler back-references are now `weak`. Added an explicit `destroy()` to the banner/interstitial/rewarded views for deterministic teardown.

### Targeting merges — `fix(M1,M2,M3)`
- **M1** — `CustomTargetingManager.applyToGamRequest` merges into the request's existing `customTargeting` instead of overwriting it (direct-sold GAM line items keyed on publisher targeting stopped matching).
- **M2** — `setGlobalOrtbConfig` seeds the merge from the current global ORTB config instead of replacing it (publisher contextual/user ORTB was being dropped).
- **M3** — `addUserData` / `updateUserData` initialize `userExt` before writing (previously silent no-ops when nil).

### Rendering — `fix(M11,M12)`
- **M11** — `AUInterstitialRenderingView` now assigns `AUInterstitialRenderingConfiguration` (the inherited IUO was nil, so touching the config surface crashed).
- **M12** — `showAd()` gated on `isReady` (showing before load silently dropped a won impression); exposed a public `isReady` on both rendering views.

### Dead slots — `fix(M8)` (+ M7 diagnostic)
- **M8** — visibility is edge-triggered, so a view that became visible before `createAd` wired up the request never retried and the slot stayed dead. Added `AUAdView.loadIfAlreadyVisible()`, called from banner/interstitial/rewarded `createAd`.
- **M7** — DEBUG diagnostic guiding integrators to `isLazyLoad = false` for standalone fullscreen ads (behavior unchanged; a product decision on fullscreen lazy semantics is deferred).

### Smart-refresh config — `fix(M4,M22)`
- **M4** — `AURemoteConfigBannerView` routes refresh through `adUnitConfiguration` (not `adUnit` directly) so the stale-aware smart-refresh logic engages and analytics report `isAutorefresh=true`.
- **M22** — clamp a positive configured interval up to Prebid's 30s floor so Prebid and the SDK's stale-aware refresh agree on the cadence.